### PR TITLE
Eliminate warning in method numberOfPages

### DIFF
--- a/AWPagedArray.h
+++ b/AWPagedArray.h
@@ -23,7 +23,7 @@
 //
 
 #import <Foundation/Foundation.h>
-#import <UIKit/UIKit.h>
+
 
 @protocol AWPagedArrayDelegate;
 

--- a/AWPagedArray.h
+++ b/AWPagedArray.h
@@ -23,6 +23,7 @@
 //
 
 #import <Foundation/Foundation.h>
+#import <UIKit/UIKit.h>
 
 @protocol AWPagedArrayDelegate;
 


### PR DESCRIPTION
Adding the UIKit framework eliminates warning in method:

- (NSUInteger)numberOfPages {
    return ceil((CGFloat)_totalCount/_objectsPerPage);
}

tested in iOS 9.1